### PR TITLE
Add skeleton for Elm 0.17 with Sass, Bootstrap 4

### DIFF
--- a/skeletons.json
+++ b/skeletons.json
@@ -627,6 +627,13 @@
       "alias": "ghost-theme-with-brunch",
       "technologies": "Babel, ES6, PostCss",
       "description": "ES6 starter project for Ghost theme development with Casper included as reference."
+    },
+    {
+      "title": "Elm 0.17 Brunch with Sass, Bootstrap 4",
+      "url": "mathieul/brunch-with-elm-bootstrap",
+      "alias": "elm-sass-bootstrap",
+      "technologies": "Elm, Babel, ES6, Sass, Bootstrap",
+      "description": "Elm 0.17 starter project with ES6, Sass and Bootstrap."
     }
   ]
 }


### PR DESCRIPTION
This is an Elm application skeleton (using the latest 0.17 version) which comes setup with Babel, Sass and Bootstrap 4.