### PR TITLE
add brunch-vue-barebones

### DIFF
--- a/skeletons.json
+++ b/skeletons.json
@@ -44,7 +44,8 @@
       "title": "Brunch with Vue (barebones)",
       "url": "tomquirk/brunch-vue-barebones",
       "technologies": "Vue, Vue-Router, Babel, ES2015",
-      "description": "A Barebones Vue Skeleton for Brunch - Minimal Dependencies!"
+      "description": "A Barebones Vue Skeleton for Brunch - Minimal Dependencies!",
+      "alias": "vue",
     },
     {
       "title": "Brunch with Sangria",

--- a/skeletons.json
+++ b/skeletons.json
@@ -41,6 +41,12 @@
       "description": "HTML5 Boilerplate, jQuery. Unsupported but still working."
     },
     {
+      "title": "Brunch with Vue (barebones)",
+      "url": "tomquirk/brunch-vue-barebones",
+      "technologies": "Vue, Vue-Router, Babel, ES2015",
+      "description": "A Barebones Vue Skeleton for Brunch - Minimal Dependencies!"
+    },
+    {
       "title": "Brunch with Sangria",
       "url": "m4ttsch/brunch-with-sangria",
       "technologies": "Babel/ES6, React, Redux, Bootstrap, jQuery, Sass, Airbnb ESLint",


### PR DESCRIPTION
Other Vue-related Brunch skeletons have many dependencies that are not applicable to all projects. This skeleton is barebones and configurable from the ground-up.