### PR TITLE
remove alias from leaflet skeleton description

### DIFF
--- a/skeletons.json
+++ b/skeletons.json
@@ -58,8 +58,7 @@
       "title": "Brunch with Leaflet",
       "url": "ngottlieb/brunch-leaflet-es6-skeleton",
       "technologies": "Leaflet, Babel, ES6",
-      "description": "A skeleton for building LeafletJS map applications with Brunch.",
-      "alias": "leaflet"
+      "description": "A skeleton for building LeafletJS map applications with Brunch."
     },
     {
       "title": "Brunch with Ractive.js",


### PR DESCRIPTION
discovered aliases don't work until a new release of this library is issued and won't work with past versions, so removed to avoid confusion